### PR TITLE
Remove unessesary iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 An IMEI number validator implemented in Rust.
 
 Add to Cargo.toml:
-```
+```toml
 imei = "1.0.0"
 ```
 
@@ -18,7 +18,7 @@ fn main() {
 ```
 
 Result:
-```
+```toml
 490154203237518: true
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,11 @@
 
 /// Check to see if an IMEI number is valid.
 pub fn valid<A: AsRef<str>>(imei: A) -> bool {
-    let chars = imei.as_ref().chars();
+    let s = imei.as_ref();
 
-    // check for number length
-    if chars.clone().count() != 15 {
+    // str::len is acceptable because if s is numeric (therefore valid),
+    //   there will not be issues with UTF-8
+    if s.len() != 15 {
         return false;
     }
 
@@ -13,7 +14,7 @@ pub fn valid<A: AsRef<str>>(imei: A) -> bool {
     let mut sum: u8 = 0;
 
     // go through each character in the imei
-    for (i, c) in chars.enumerate() {
+    for (i, c) in s.chars().enumerate() {
         // convert the chars into u8
         // I precalculated these so it doesn't have to parse the char as a string
         // It also makes sure that the input is only numeric


### PR DESCRIPTION
I was reading your code and noticed that you were iterating the string twice where you didn't need to. `Iterator::count` will consume the iterator. Of course, `chars.clone()` only duplicates the iterator (since the iter holds only a reference to the string), but it still needs to consume that copy to count  the number of items. This extra iteration is unnecessary because the `str` (that you got from `AsRef::as_ref`) stores the length of its buffer.

On my hardware, your code gets 2227 ns average. With my changes, I got 1540 ns. The kicker is `cargo test --release` though... 90 ns with yours and 78 ns with mine. Looks like the compiler guys are better at optimizing than either of us.

There's a couple other versions of basically the same algorithm that are more aggressively optimized using arrays, the `luhn3` and `isin` crates are the ones I'm thinking of.