### PR TITLE
Implement serde traits with validation for Imei

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,14 @@ exclude = ["target", "Cargo.lock"]
 keywords = ["imei", "luhn", "phone", "mobile", "no_std"]
 edition = "2021"
 
+[dependencies]
+serde = { version = "1.0.158", features = ["derive"], optional = true }
+
 [dev-dependencies]
 chrono = "0.4"
+serde_json = "1.0.94"
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 std = []
+serde = ["dep:serde"]

--- a/tests/speed.rs
+++ b/tests/speed.rs
@@ -34,3 +34,20 @@ fn test() -> i64 {
 
     difference
 }
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_serde() {
+    use imei::Imei;
+    use serde::Deserialize;
+
+    #[derive(serde::Serialize, Deserialize)]
+    struct ContainsImei {
+        imei: Imei<String>,
+    }
+
+    let json = serde_json::to_string(&Imei::try_new("354406185514933").unwrap()).unwrap();
+    assert_eq!(json, "\"354406185514933\"");
+    let imei: Imei<String> = serde_json::from_str("\"354406185514933\"").unwrap();
+    assert_eq!(imei, Imei::try_new("354406185514933".to_string()).unwrap())
+}


### PR DESCRIPTION
I customly implemented `serde::Serialize`  and `serde::Deserialize` for `Imei`, to have it be serialized directly as a string, and have it be validated upon attempting to deserialize it from a string