### PR TITLE
Implement utoipa traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,15 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
+utoipa = { version = "3.3.0", optional = true }
+serde_json = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 chrono = "0.4"
 serde_json = "1.0"
 
 [features]
-default = ["std", "serde"]
+default = ["std", "serde", "openapi"]
 std = []
 serde = ["dep:serde"]
+openapi = ["dep:utoipa", "dep:serde_json"]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Typically, the validation process sub 1000th of a milisecond (practically instan
 ## Features
  - The `std` is enabled by default which implements `error::Error` for `imei::Error`.
  - The `serde` feature adds serialization/deserialization for the `Imei` struct.
+ - The `openapi` adds implementations for `utoipa::ToSchema` and `utoipa::ToResponse`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,45 @@ impl<I: AsRef<str>> Display for Imei<I> {
     }
 }
 
+#[cfg(feature = "openapi")]
+mod openapi {
+    use serde_json::json;
+    use utoipa::{
+        openapi::{
+            response::Response, schema::Schema, ObjectBuilder, RefOr, ResponseBuilder, SchemaType,
+        },
+        ToResponse, ToSchema,
+    };
+
+    use crate::Imei;
+
+    impl<'r, I: AsRef<str>> ToResponse<'r> for Imei<I> {
+        fn response() -> (&'r str, RefOr<Response>) {
+            (
+                "Imei",
+                ResponseBuilder::new()
+                    .description("A valid International Mobile Equipment Identity number")
+                    .build()
+                    .into(),
+            )
+        }
+    }
+
+    impl<'s, I: AsRef<str>> ToSchema<'s> for Imei<I> {
+        fn schema() -> (&'s str, RefOr<Schema>) {
+            (
+                "Imei",
+                ObjectBuilder::new()
+                    .schema_type(SchemaType::String)
+                    // IMEI consists of 15 digits
+                    .pattern(Some(r"^\d{15}$"))
+                    .example(Some(json!("522872587498800")))
+                    .into(),
+            )
+        }
+    }
+}
+
 /// Check to see if an IMEI number is valid.
 pub fn valid<A: AsRef<str>>(imei: A) -> bool {
     let s = imei.as_ref();


### PR DESCRIPTION
Implement `ToResponse` and `ToSchema`  traits from `utoipa`, allowing generation of OpenAPI spec for `Imei` using `utoipa`. 

I've put it behind the `openapi` feature gate, which is disabled by default